### PR TITLE
Add no-op version of all ShouldBe* that contains value.

### DIFF
--- a/LanguageExt.UnitTesting.Tests/EitherAsyncExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/EitherAsyncExtensionsTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
 
 namespace LanguageExt.UnitTesting.Tests
 {
@@ -11,19 +10,19 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeRight_GivenLeft_Throws()
         {
-            Func<Task> act = () => GetLeft().ShouldBeRight(ValidationNoop);
+            Func<Task> act = () => GetLeft().ShouldBeRight();
             act.Should().Throw<Exception>().WithMessage("Expected Right, got Left instead.");
         }
 
         [Fact]
         public static void ShouldBeLeft_GivenRight_Throws()
         {
-            Func<Task> act = () => GetRight().ShouldBeLeft(ValidationNoop);
+            Func<Task> act = () => GetRight().ShouldBeLeft();
             act.Should().Throw<Exception>().WithMessage("Expected Left, got Right instead.");
         }
 
         [Fact]
-        public static async Task ShouldBeLeft_GivenLeft_RunsValidation()
+        public static async Task ShouldBeLeft_GivenLeftWithValidation_RunsValidation()
         {
             var validationRan = false;
             await GetLeft().ShouldBeLeft(x => validationRan = true);
@@ -31,13 +30,11 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static async Task ShouldBeLeft_GivenLeft_DoesNotThrow()
-        {
-            await GetLeft().ShouldBeLeft();
-        }
+        public static async Task ShouldBeLeft_GivenLeftNoValidation_DoesNotThrow()
+            => await GetLeft().ShouldBeLeft();
 
         [Fact]
-        public static async Task ShouldBeRight_GivenRight_RunsValidation()
+        public static async Task ShouldBeRight_GivenRightWithValidation_RunsValidation()
         {
             var validationRan = false;
             await GetRight().ShouldBeRight(x => validationRan = true);
@@ -45,10 +42,8 @@ namespace LanguageExt.UnitTesting.Tests
         }
         
         [Fact]
-        public static async Task ShouldBeRight_GivenRight_DoesNotThrow()
-        {
-            await GetRight().ShouldBeRight();
-        }
+        public static async Task ShouldBeRight_GivenRightNoValidation_DoesNotThrow()
+            => await GetRight().ShouldBeRight();
 
         private static EitherAsync<int, string> GetLeft() => 123;
         private static EitherAsync<int, string> GetRight() => "right";

--- a/LanguageExt.UnitTesting.Tests/EitherAsyncExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/EitherAsyncExtensionsTests.cs
@@ -31,11 +31,23 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
+        public static async Task ShouldBeLeft_GivenLeft_DoesNotThrow()
+        {
+            await GetLeft().ShouldBeLeft();
+        }
+
+        [Fact]
         public static async Task ShouldBeRight_GivenRight_RunsValidation()
         {
             var validationRan = false;
             await GetRight().ShouldBeRight(x => validationRan = true);
             validationRan.Should().BeTrue();
+        }
+        
+        [Fact]
+        public static async Task ShouldBeRight_GivenRight_DoesNotThrow()
+        {
+            await GetRight().ShouldBeRight();
         }
 
         private static EitherAsync<int, string> GetLeft() => 123;

--- a/LanguageExt.UnitTesting.Tests/EitherExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/EitherExtensionsTests.cs
@@ -30,11 +30,23 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
+        public static void ShouldBeLeft_GivenLeft_DoesNotThrow()
+        {
+            GetLeft().ShouldBeLeft();
+        }
+
+        [Fact]
         public static void ShouldBeRight_GivenRight_RunsValidation()
         {
             var validationRan = false;
             GetRight().ShouldBeRight(x => validationRan = true);
             validationRan.Should().BeTrue();
+        }
+
+        [Fact]
+        public static void ShouldBeRight_GivenRight_DoesNotThrow()
+        {
+            GetRight().ShouldBeRight();
         }
 
         private static Either<int, string> GetLeft() => 123;

--- a/LanguageExt.UnitTesting.Tests/EitherExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/EitherExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
 
 namespace LanguageExt.UnitTesting.Tests
 {
@@ -10,19 +9,19 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeRight_GivenLeft_Throws()
         {
-            Action act = () => GetLeft().ShouldBeRight(ValidationNoop);
+            Action act = () => GetLeft().ShouldBeRight();
             act.Should().Throw<Exception>().WithMessage("Expected Right, got Left instead.");
         }
 
         [Fact]
         public static void ShouldBeLeft_GivenRight_Throws()
         {
-            Action act = () => GetRight().ShouldBeLeft(ValidationNoop);
+            Action act = () => GetRight().ShouldBeLeft();
             act.Should().Throw<Exception>().WithMessage("Expected Left, got Right instead.");
         }
 
         [Fact]
-        public static void ShouldBeLeft_GivenLeft_RunsValidation()
+        public static void ShouldBeLeft_GivenLeftWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetLeft().ShouldBeLeft(x => validationRan = true);
@@ -30,13 +29,11 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static void ShouldBeLeft_GivenLeft_DoesNotThrow()
-        {
-            GetLeft().ShouldBeLeft();
-        }
+        public static void ShouldBeLeft_GivenLeftNoValidation_DoesNotThrow()
+            => GetLeft().ShouldBeLeft();
 
         [Fact]
-        public static void ShouldBeRight_GivenRight_RunsValidation()
+        public static void ShouldBeRight_GivenRightWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetRight().ShouldBeRight(x => validationRan = true);
@@ -44,10 +41,8 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static void ShouldBeRight_GivenRight_DoesNotThrow()
-        {
-            GetRight().ShouldBeRight();
-        }
+        public static void ShouldBeRight_GivenRightNoValidation_DoesNotThrow()
+            => GetRight().ShouldBeRight();
 
         private static Either<int, string> GetLeft() => 123;
         private static Either<int, string> GetRight() => "right";

--- a/LanguageExt.UnitTesting.Tests/OptionAsyncExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/OptionAsyncExtensionsTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
 
 namespace LanguageExt.UnitTesting.Tests
 {
@@ -11,7 +10,7 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeSome_GivenNone_Throws()
         {
-            Func<Task> act = () => GetNone().ShouldBeSome(ValidationNoop);
+            Func<Task> act = () => GetNone().ShouldBeSome();
             act.Should().Throw<Exception>().WithMessage("Expected Some, got None instead.");
         }
 
@@ -23,7 +22,7 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static async Task ShouldBeSome_GivenSome_RunsValidation()
+        public static async Task ShouldBeSome_GivenSomeWithValidation_RunsValidation()
         {
             var validationRan = false;
             await GetSome().ShouldBeSome(x => validationRan = true);
@@ -31,10 +30,8 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static async Task ShouldBeSome_GivenSome_DoesNotThrow()
-        {
-            await GetSome().ShouldBeSome();
-        }
+        public static async Task ShouldBeSome_GivenSomeNoValidation_DoesNotThrow() 
+            => await GetSome().ShouldBeSome();
 
         [Fact]
         public static async Task ShouldBeNone_GivenNone_DoesNotThrow()

--- a/LanguageExt.UnitTesting.Tests/OptionAsyncExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/OptionAsyncExtensionsTests.cs
@@ -31,6 +31,12 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
+        public static async Task ShouldBeSome_GivenSome_DoesNotThrow()
+        {
+            await GetSome().ShouldBeSome();
+        }
+
+        [Fact]
         public static async Task ShouldBeNone_GivenNone_DoesNotThrow()
         {
             Func<Task> act = () => GetNone().ShouldBeNone();

--- a/LanguageExt.UnitTesting.Tests/OptionExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/OptionExtensionsTests.cs
@@ -28,6 +28,9 @@ namespace LanguageExt.UnitTesting.Tests
             GetSome().ShouldBeSome(x => validationRan = true);
             validationRan.Should().BeTrue();
         }
+        
+        [Fact]
+        public static void ShouldBeSome_GivenSome_NoValidation_DoesNotThrow() => GetSome().ShouldBeSome();
 
         [Fact]
         public static void ShouldBeNone_GivenNone_DoesNotThrow() => GetNone().ShouldBeNone();

--- a/LanguageExt.UnitTesting.Tests/OptionExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/OptionExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
 
 namespace LanguageExt.UnitTesting.Tests
 {
@@ -10,7 +9,7 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeSome_GivenNone_Throws()
         {
-            Action act = () => GetNone().ShouldBeSome(ValidationNoop);
+            Action act = () => GetNone().ShouldBeSome();
             act.Should().Throw<Exception>().WithMessage("Expected Some, got None instead.");
         }
 
@@ -22,7 +21,7 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static void ShouldBeSome_GivenSome_RunsValidation()
+        public static void ShouldBeSome_GivenSomeWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetSome().ShouldBeSome(x => validationRan = true);
@@ -30,7 +29,8 @@ namespace LanguageExt.UnitTesting.Tests
         }
         
         [Fact]
-        public static void ShouldBeSome_GivenSome_NoValidation_DoesNotThrow() => GetSome().ShouldBeSome();
+        public static void ShouldBeSome_GivenSomeNoValidation_DoesNotThrow()
+            => GetSome().ShouldBeSome();
 
         [Fact]
         public static void ShouldBeNone_GivenNone_DoesNotThrow() => GetNone().ShouldBeNone();

--- a/LanguageExt.UnitTesting.Tests/TestsHelper.cs
+++ b/LanguageExt.UnitTesting.Tests/TestsHelper.cs
@@ -1,7 +1,0 @@
-﻿namespace LanguageExt.UnitTesting.Tests
-{
-    public static class TestsHelper
-    {
-        public static void ValidationNoop<T>(T _) {}
-    }
-}

--- a/LanguageExt.UnitTesting.Tests/TryAsyncExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/TryAsyncExtensionsTests.cs
@@ -2,8 +2,6 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
-
 namespace LanguageExt.UnitTesting.Tests
 {
     public static class TryAsyncExtensionsTests
@@ -11,32 +9,30 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeFail_GivenSuccess_Throws()
         {
-            Func<Task> act = () => GetSuccess().ShouldBeFail(ValidationNoop);
+            Func<Task> act = () => GetSuccess().ShouldBeFail();
             act.Should().Throw<Exception>().WithMessage("Expected Fail, got Success instead.");
         }
 
         [Fact]
         public static void ShouldBeSuccess_GivenFail_Throws()
         {
-            Func<Task> act = () => GetFail().ShouldBeSuccess(ValidationNoop);
+            Func<Task> act = () => GetFail().ShouldBeSuccess();
             act.Should().Throw<Exception>().WithMessage("Expected Success, got Fail instead.");
         }
 
         [Fact]
-        public static async Task ShouldBeFail_GivenFail_RunsValidation()
+        public static async Task ShouldBeFail_GivenFailWithValidation_RunsValidation()
         {
             var validationRan = false;
             await GetFail().ShouldBeFail(x => validationRan = true);
             validationRan.Should().BeTrue();
         }
         [Fact]
-        public static async Task ShouldBeFail_GivenFail_DoesNotThrow()
-        {
-            await GetFail().ShouldBeFail();
-        }
+        public static async Task ShouldBeFail_GivenFailNoValidation_DoesNotThrow()
+            => await GetFail().ShouldBeFail();
 
         [Fact]
-        public static async Task ShouldBeSuccess_GivenSuccess_RunsValidation()
+        public static async Task ShouldBeSuccess_GivenSuccessWithValidation_RunsValidation()
         {
             var validationRan = false;
             await GetSuccess().ShouldBeSuccess(x => validationRan = true);
@@ -44,10 +40,8 @@ namespace LanguageExt.UnitTesting.Tests
         }
         
         [Fact]
-        public static async Task ShouldBeSuccess_GivenSuccess_DoesNotThrow()
-        {
-            await GetSuccess().ShouldBeSuccess();
-        }
+        public static async Task ShouldBeSuccess_GivenSuccessNoValidation_DoesNotThrow()
+            => await GetSuccess().ShouldBeSuccess();
 
         private static TryAsync<string> GetFail() => () => throw new Exception();
         private static TryAsync<string> GetSuccess() => async () => await Task.FromResult("success");

--- a/LanguageExt.UnitTesting.Tests/TryAsyncExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/TryAsyncExtensionsTests.cs
@@ -29,6 +29,11 @@ namespace LanguageExt.UnitTesting.Tests
             await GetFail().ShouldBeFail(x => validationRan = true);
             validationRan.Should().BeTrue();
         }
+        [Fact]
+        public static async Task ShouldBeFail_GivenFail_DoesNotThrow()
+        {
+            await GetFail().ShouldBeFail();
+        }
 
         [Fact]
         public static async Task ShouldBeSuccess_GivenSuccess_RunsValidation()
@@ -36,6 +41,12 @@ namespace LanguageExt.UnitTesting.Tests
             var validationRan = false;
             await GetSuccess().ShouldBeSuccess(x => validationRan = true);
             validationRan.Should().BeTrue();
+        }
+        
+        [Fact]
+        public static async Task ShouldBeSuccess_GivenSuccess_DoesNotThrow()
+        {
+            await GetSuccess().ShouldBeSuccess();
         }
 
         private static TryAsync<string> GetFail() => () => throw new Exception();

--- a/LanguageExt.UnitTesting.Tests/TryExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/TryExtensionsTests.cs
@@ -30,11 +30,22 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
+        public static void ShouldBeFail_GivenFail_DoesNotThrow()
+        {
+            GetFail().ShouldBeFail();
+        }
+
+        [Fact]
         public static void ShouldBeSuccess_GivenSuccess_RunsValidation()
         {
             var validationRan = false;
             GetSuccess().ShouldBeSuccess(x => validationRan = true);
             validationRan.Should().BeTrue();
+        }
+        [Fact]
+        public static void ShouldBeSuccess_GivenSuccess_DoesNotThrow()
+        {
+            GetSuccess().ShouldBeSuccess();
         }
 
         private static Try<string> GetFail() => () => throw new Exception();

--- a/LanguageExt.UnitTesting.Tests/TryExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/TryExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
 
 namespace LanguageExt.UnitTesting.Tests
 {
@@ -10,19 +9,19 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeFail_GivenSuccess_Throws()
         {
-            Action act = () => GetSuccess().ShouldBeFail(ValidationNoop);
+            Action act = () => GetSuccess().ShouldBeFail();
             act.Should().Throw<Exception>().WithMessage("Expected Fail, got Success instead.");
         }
 
         [Fact]
         public static void ShouldBeSuccess_GivenFail_Throws()
         {
-            Action act = () => GetFail().ShouldBeSuccess(ValidationNoop);
+            Action act = () => GetFail().ShouldBeSuccess();
             act.Should().Throw<Exception>().WithMessage("Expected Success, got Fail instead.");
         }
 
         [Fact]
-        public static void ShouldBeFail_GivenFail_RunsValidation()
+        public static void ShouldBeFail_GivenFailWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetFail().ShouldBeFail(x => validationRan = true);
@@ -30,23 +29,19 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static void ShouldBeFail_GivenFail_DoesNotThrow()
-        {
-            GetFail().ShouldBeFail();
-        }
+        public static void ShouldBeFail_GivenFailNoValidation_DoesNotThrow()
+            => GetFail().ShouldBeFail();
 
         [Fact]
-        public static void ShouldBeSuccess_GivenSuccess_RunsValidation()
+        public static void ShouldBeSuccess_GivenSuccessWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetSuccess().ShouldBeSuccess(x => validationRan = true);
             validationRan.Should().BeTrue();
         }
         [Fact]
-        public static void ShouldBeSuccess_GivenSuccess_DoesNotThrow()
-        {
-            GetSuccess().ShouldBeSuccess();
-        }
+        public static void ShouldBeSuccess_GivenSuccessNoValidation_DoesNotThrow()
+            => GetSuccess().ShouldBeSuccess();
 
         private static Try<string> GetFail() => () => throw new Exception();
         private static Try<string> GetSuccess() => () => "success";

--- a/LanguageExt.UnitTesting.Tests/TryOptionAsyncExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/TryOptionAsyncExtensionsTests.cs
@@ -29,6 +29,12 @@ namespace LanguageExt.UnitTesting.Tests
             await GetFail().ShouldBeFail(x => validationRan = true);
             validationRan.Should().BeTrue();
         }
+        
+        [Fact]
+        public static async Task ShouldBeFail_GivenFail_DoesNotThrow()
+        {
+            await GetFail().ShouldBeFail();
+        }
 
         [Fact]
         public static void ShouldBeSome_GivenNone_Throws()
@@ -48,11 +54,18 @@ namespace LanguageExt.UnitTesting.Tests
         public static async Task ShouldBeSome_GivenSome_RunsValidation()
         {
             var validationRan = false;
-            await GetSuccessSome().ShouldBeSome(x => {
-                    x.Should().Be(123);
-                    validationRan = true;
-                });
+            await GetSuccessSome().ShouldBeSome(x =>
+            {
+                x.Should().Be(123);
+                validationRan = true;
+            });
             validationRan.Should().BeTrue();
+        }
+
+        [Fact]
+        public static async Task ShouldBeSome_GivenSome_DoesNotThrow()
+        {
+            await GetSuccessSome().ShouldBeSome();
         }
 
         [Fact]

--- a/LanguageExt.UnitTesting.Tests/TryOptionAsyncExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/TryOptionAsyncExtensionsTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
 
 namespace LanguageExt.UnitTesting.Tests
 {
@@ -11,19 +10,19 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeFail_GivenSuccessSome_Throws()
         {
-            Func<Task> act = () => GetSuccessSome().ShouldBeFail(ValidationNoop);
+            Func<Task> act = () => GetSuccessSome().ShouldBeFail();
             act.Should().Throw<Exception>().WithMessage("Expected Fail, got Some instead.");
         }
 
         [Fact]
         public static void ShouldBeFail_GivenSuccessNone_Throws()
         {
-            Func<Task> act = () => GetSuccessNone().ShouldBeFail(ValidationNoop);
+            Func<Task> act = () => GetSuccessNone().ShouldBeFail();
             act.Should().Throw<Exception>().WithMessage("Expected Fail, got None instead.");
         }
 
         [Fact]
-        public static async Task ShouldBeFail_GivenFail_RunsValidation()
+        public static async Task ShouldBeFail_GivenFailWithValidation_RunsValidation()
         {
             var validationRan = false;
             await GetFail().ShouldBeFail(x => validationRan = true);
@@ -31,27 +30,25 @@ namespace LanguageExt.UnitTesting.Tests
         }
         
         [Fact]
-        public static async Task ShouldBeFail_GivenFail_DoesNotThrow()
-        {
-            await GetFail().ShouldBeFail();
-        }
+        public static async Task ShouldBeFail_GivenFailNoValidation_DoesNotThrow()
+            => await GetFail().ShouldBeFail();
 
         [Fact]
         public static void ShouldBeSome_GivenNone_Throws()
         {
-            Func<Task> act = () => GetSuccessNone().ShouldBeSome(ValidationNoop);
+            Func<Task> act = () => GetSuccessNone().ShouldBeSome();
             act.Should().Throw<Exception>().WithMessage("Expected Some, got None instead.");
         }
 
         [Fact]
         public static void ShouldBeSome_GivenFail_Throws()
         {
-            Func<Task> act = () => GetFail().ShouldBeSome(ValidationNoop);
+            Func<Task> act = () => GetFail().ShouldBeSome();
             act.Should().Throw<Exception>().WithMessage("something went wrong");
         }
 
         [Fact]
-        public static async Task ShouldBeSome_GivenSome_RunsValidation()
+        public static async Task ShouldBeSome_GivenSomeWithValidation_RunsValidation()
         {
             var validationRan = false;
             await GetSuccessSome().ShouldBeSome(x =>
@@ -63,10 +60,8 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static async Task ShouldBeSome_GivenSome_DoesNotThrow()
-        {
-            await GetSuccessSome().ShouldBeSome();
-        }
+        public static async Task  ShouldBeSome_GivenSomeNoValidation_DoesNotThrow()
+            => await GetSuccessSome().ShouldBeSome();
 
         [Fact]
         public static void ShouldBeNone_GivenSome_Throws()

--- a/LanguageExt.UnitTesting.Tests/TryOptionExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/TryOptionExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
 
 namespace LanguageExt.UnitTesting.Tests
 {
@@ -10,19 +9,19 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeFail_GivenSuccessSome_Throws()
         {
-            Action act = () => GetSuccessSome().ShouldBeFail(ValidationNoop);
+            Action act = () => GetSuccessSome().ShouldBeFail();
             act.Should().Throw<Exception>().WithMessage("Expected Fail, got Some instead.");
         }
 
         [Fact]
         public static void ShouldBeFail_GivenSuccessNone_Throws()
         {
-            Action act = () => GetSuccessNone().ShouldBeFail(ValidationNoop);
+            Action act = () => GetSuccessNone().ShouldBeFail();
             act.Should().Throw<Exception>().WithMessage("Expected Fail, got None instead.");
         }
 
         [Fact]
-        public static void ShouldBeFail_GivenFail_RunsValidation()
+        public static void ShouldBeFail_GivenFailWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetFail().ShouldBeFail(x => validationRan = true);
@@ -30,27 +29,25 @@ namespace LanguageExt.UnitTesting.Tests
         }
         
         [Fact]
-        public static void ShouldBeFail_GivenFail_DoesNotThrow()
-        {
-            GetFail().ShouldBeFail();
-        }
+        public static void ShouldBeFail_GivenFailNoValidation_DoesNotThrow()
+            => GetFail().ShouldBeFail();
 
         [Fact]
         public static void ShouldBeSome_GivenNone_Throws()
         {
-            Action act = () => GetSuccessNone().ShouldBeSome(ValidationNoop);
+            Action act = () => GetSuccessNone().ShouldBeSome();
             act.Should().Throw<Exception>().WithMessage("Expected Some, got None instead.");
         }
 
         [Fact]
         public static void ShouldBeSome_GivenFail_Throws()
         {
-            Action act = () => GetFail().ShouldBeSome(ValidationNoop);
+            Action act = () => GetFail().ShouldBeSome();
             act.Should().Throw<Exception>().WithMessage("something went wrong");
         }
 
         [Fact]
-        public static void ShouldBeSome_GivenSome_RunsValidation()
+        public static void ShouldBeSome_GivenSomeWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetSuccessSome().ShouldBeSome(x =>
@@ -62,10 +59,8 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static void ShouldBeSome_GivenSome_DoesNotThrow()
-        {
-            GetSuccessSome().ShouldBeSome();
-        }
+        public static void ShouldBeSome_GivenSomeNoValidation_DoesNotThrow()
+            => GetSuccessSome().ShouldBeSome();
 
         [Fact]
         public static void ShouldBeNone_GivenSome_Throws()
@@ -83,9 +78,7 @@ namespace LanguageExt.UnitTesting.Tests
 
         [Fact]
         public static void ShouldBeNone_GivenNone_DoesNotThrow()
-        {
-            GetSuccessNone().ShouldBeNone();
-        }
+            => GetSuccessNone().ShouldBeNone();
 
         private static TryOption<int> GetFail() => () => throw new Exception("something went wrong");
         private static TryOption<int> GetSuccessSome() => () => 123;

--- a/LanguageExt.UnitTesting.Tests/TryOptionExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/TryOptionExtensionsTests.cs
@@ -28,6 +28,12 @@ namespace LanguageExt.UnitTesting.Tests
             GetFail().ShouldBeFail(x => validationRan = true);
             validationRan.Should().BeTrue();
         }
+        
+        [Fact]
+        public static void ShouldBeFail_GivenFail_DoesNotThrow()
+        {
+            GetFail().ShouldBeFail();
+        }
 
         [Fact]
         public static void ShouldBeSome_GivenNone_Throws()
@@ -47,11 +53,18 @@ namespace LanguageExt.UnitTesting.Tests
         public static void ShouldBeSome_GivenSome_RunsValidation()
         {
             var validationRan = false;
-            GetSuccessSome().ShouldBeSome(x => {
-                    x.Should().Be(123);
-                    validationRan = true;
-                });
+            GetSuccessSome().ShouldBeSome(x =>
+            {
+                x.Should().Be(123);
+                validationRan = true;
+            });
             validationRan.Should().BeTrue();
+        }
+
+        [Fact]
+        public static void ShouldBeSome_GivenSome_DoesNotThrow()
+        {
+            GetSuccessSome().ShouldBeSome();
         }
 
         [Fact]

--- a/LanguageExt.UnitTesting.Tests/ValidationExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/ValidationExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.UnitTesting.Tests.TestsHelper;
 
 namespace LanguageExt.UnitTesting.Tests
 {
@@ -10,19 +9,19 @@ namespace LanguageExt.UnitTesting.Tests
         [Fact]
         public static void ShouldBeFail_GivenSuccess_Throws()
         {
-            Action act = () => GetSuccess().ShouldBeFail(ValidationNoop);
+            Action act = () => GetSuccess().ShouldBeFail();
             act.Should().Throw<Exception>().WithMessage("Expected Fail, got Success instead.");
         }
 
         [Fact]
         public static void ShouldBeSuccess_GivenFail_Throws()
         {
-            Action act = () => GetFail().ShouldBeSuccess(ValidationNoop);
+            Action act = () => GetFail().ShouldBeSuccess();
             act.Should().Throw<Exception>().WithMessage("Expected Success, got Fail instead.");
         }
 
         [Fact]
-        public static void ShouldBeFail_GivenFail_RunsValidation()
+        public static void ShouldBeFail_GivenFailWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetFail().ShouldBeFail(x => validationRan = true);
@@ -30,20 +29,20 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
-        public static void ShouldBeFail_GivenFail_DoesNotThrow()
-        {
-            GetFail().ShouldBeFail();
-        }
+        public static void ShouldBeFail_GivenFailNoValidation_DoesNotThrow()
+            => GetFail().ShouldBeFail();
 
         [Fact]
-        public static void ShouldBeSuccess_GivenSuccess_RunsValidation()
+        public static void ShouldBeSuccess_GivenSuccessWithValidation_RunsValidation()
         {
             var validationRan = false;
             GetSuccess().ShouldBeSuccess(x => validationRan = true);
             validationRan.Should().BeTrue();
-            
-            GetSuccess().ShouldBeSuccess();
         }
+
+        [Fact]
+        public static void ShouldBeSuccess_GivenSuccessNoValidation_DoesNotThrow()
+            => GetSuccess().ShouldBeSuccess();
 
         private static Validation<int, string> GetFail() => 123;
         private static Validation<int, string> GetSuccess() => "success";

--- a/LanguageExt.UnitTesting.Tests/ValidationExtensionsTests.cs
+++ b/LanguageExt.UnitTesting.Tests/ValidationExtensionsTests.cs
@@ -30,11 +30,19 @@ namespace LanguageExt.UnitTesting.Tests
         }
 
         [Fact]
+        public static void ShouldBeFail_GivenFail_DoesNotThrow()
+        {
+            GetFail().ShouldBeFail();
+        }
+
+        [Fact]
         public static void ShouldBeSuccess_GivenSuccess_RunsValidation()
         {
             var validationRan = false;
             GetSuccess().ShouldBeSuccess(x => validationRan = true);
             validationRan.Should().BeTrue();
+            
+            GetSuccess().ShouldBeSuccess();
         }
 
         private static Validation<int, string> GetFail() => 123;

--- a/LanguageExt.UnitTesting/Common.cs
+++ b/LanguageExt.UnitTesting/Common.cs
@@ -32,5 +32,7 @@ namespace LanguageExt.UnitTesting
         { 
             /* we should end up in here*/
         }
+
+        internal static void Noop<T>(T _) {} 
     }
 }

--- a/LanguageExt.UnitTesting/EitherAsyncExtensions.cs
+++ b/LanguageExt.UnitTesting/EitherAsyncExtensions.cs
@@ -7,12 +7,10 @@ namespace LanguageExt.UnitTesting
     {
         public static async Task ShouldBeRight<TLeft, TRight>(this EitherAsync<TLeft, TRight> @this,
                                                               Action<TRight> rightValidation = null)
-            => await @this.Match(rightValidation ?? Common.Noop,
-                                 Common.ThrowIfLeft);
+            => await @this.Match(rightValidation ?? Common.Noop, Common.ThrowIfLeft);
 
         public static async Task ShouldBeLeft<TLeft, TRight>(this EitherAsync<TLeft, TRight> @this,
                                                              Action<TLeft> leftValidation = null)
-            => await @this.Match(Common.ThrowIfRight,
-                                 leftValidation ?? Common.Noop);
+            => await @this.Match(Common.ThrowIfRight, leftValidation ?? Common.Noop);
     }
 }

--- a/LanguageExt.UnitTesting/EitherAsyncExtensions.cs
+++ b/LanguageExt.UnitTesting/EitherAsyncExtensions.cs
@@ -5,10 +5,14 @@ namespace LanguageExt.UnitTesting
 {
     public static class EitherAsyncExtensions
     {
-        public static async Task ShouldBeRight<TLeft, TRight>(this EitherAsync<TLeft, TRight> @this, Action<TRight> rightValidation)
-            => await @this.Match(rightValidation, Common.ThrowIfLeft);
+        public static async Task ShouldBeRight<TLeft, TRight>(this EitherAsync<TLeft, TRight> @this,
+                                                              Action<TRight> rightValidation = null)
+            => await @this.Match(rightValidation ?? Common.Noop,
+                                 Common.ThrowIfLeft);
 
-        public static async Task ShouldBeLeft<TLeft, TRight>(this EitherAsync<TLeft, TRight> @this, Action<TLeft> leftValidation)
-            => await @this.Match(Common.ThrowIfRight, leftValidation);
+        public static async Task ShouldBeLeft<TLeft, TRight>(this EitherAsync<TLeft, TRight> @this,
+                                                             Action<TLeft> leftValidation = null)
+            => await @this.Match(Common.ThrowIfRight,
+                                 leftValidation ?? Common.Noop);
     }
 }

--- a/LanguageExt.UnitTesting/EitherExtensions.cs
+++ b/LanguageExt.UnitTesting/EitherExtensions.cs
@@ -4,10 +4,14 @@ namespace LanguageExt.UnitTesting
 {
     public static class EitherExtensions
     {
-        public static void ShouldBeRight<TLeft, TRight>(this Either<TLeft, TRight> @this, Action<TRight> rightValidation)
-            => @this.Match(rightValidation, Common.ThrowIfLeft);
+        public static void ShouldBeRight<TLeft, TRight>(this Either<TLeft, TRight> @this,
+                                                        Action<TRight> rightValidation = null)
+            => @this.Match(rightValidation ?? Common.Noop,
+                           Common.ThrowIfLeft);
 
-        public static void ShouldBeLeft<TLeft, TRight>(this Either<TLeft, TRight> @this, Action<TLeft> leftValidation)
-            => @this.Match(Common.ThrowIfRight, leftValidation);
+        public static void ShouldBeLeft<TLeft, TRight>(this Either<TLeft, TRight> @this,
+                                                       Action<TLeft> leftValidation = null)
+            => @this.Match(Common.ThrowIfRight,
+                           leftValidation ?? Common.Noop);
     }
 }

--- a/LanguageExt.UnitTesting/EitherExtensions.cs
+++ b/LanguageExt.UnitTesting/EitherExtensions.cs
@@ -6,12 +6,10 @@ namespace LanguageExt.UnitTesting
     {
         public static void ShouldBeRight<TLeft, TRight>(this Either<TLeft, TRight> @this,
                                                         Action<TRight> rightValidation = null)
-            => @this.Match(rightValidation ?? Common.Noop,
-                           Common.ThrowIfLeft);
+            => @this.Match(rightValidation ?? Common.Noop, Common.ThrowIfLeft);
 
         public static void ShouldBeLeft<TLeft, TRight>(this Either<TLeft, TRight> @this,
                                                        Action<TLeft> leftValidation = null)
-            => @this.Match(Common.ThrowIfRight,
-                           leftValidation ?? Common.Noop);
+            => @this.Match(Common.ThrowIfRight, leftValidation ?? Common.Noop);
     }
 }

--- a/LanguageExt.UnitTesting/OptionAsyncExtensions.cs
+++ b/LanguageExt.UnitTesting/OptionAsyncExtensions.cs
@@ -5,8 +5,9 @@ namespace LanguageExt.UnitTesting
 {
     public static class OptionAsyncExtensions
     {
-        public static async Task ShouldBeSome<T>(this OptionAsync<T> @this, Action<T> someValidation) =>
-            await @this.Match(Some: someValidation, None: Common.ThrowIfNone);
+        public static async Task ShouldBeSome<T>(this OptionAsync<T> @this, Action<T> someValidation = null) =>
+            await @this.Match(Some: someValidation ?? Common.Noop,
+                              None: Common.ThrowIfNone);
 
         public static async Task ShouldBeNone<T>(this OptionAsync<T> @this) =>
             await @this.Match(Some: Common.ThrowIfSome, None: Common.SuccessfulNone);

--- a/LanguageExt.UnitTesting/OptionAsyncExtensions.cs
+++ b/LanguageExt.UnitTesting/OptionAsyncExtensions.cs
@@ -6,8 +6,7 @@ namespace LanguageExt.UnitTesting
     public static class OptionAsyncExtensions
     {
         public static async Task ShouldBeSome<T>(this OptionAsync<T> @this, Action<T> someValidation = null) =>
-            await @this.Match(Some: someValidation ?? Common.Noop,
-                              None: Common.ThrowIfNone);
+            await @this.Match(Some: someValidation ?? Common.Noop, None: Common.ThrowIfNone);
 
         public static async Task ShouldBeNone<T>(this OptionAsync<T> @this) =>
             await @this.Match(Some: Common.ThrowIfSome, None: Common.SuccessfulNone);

--- a/LanguageExt.UnitTesting/OptionExtensions.cs
+++ b/LanguageExt.UnitTesting/OptionExtensions.cs
@@ -5,8 +5,7 @@ namespace LanguageExt.UnitTesting
     
     public static class OptionExtensions
     {
-        public static void ShouldBeSome<T>(this Option<T> @this,
-                                           Action<T> someValidation = null)
+        public static void ShouldBeSome<T>(this Option<T> @this, Action<T> someValidation = null)
             => @this.Match(
                 Some: someValidation ?? Common.Noop,
                 None: Common.ThrowIfNone);

--- a/LanguageExt.UnitTesting/OptionExtensions.cs
+++ b/LanguageExt.UnitTesting/OptionExtensions.cs
@@ -2,11 +2,13 @@
 
 namespace LanguageExt.UnitTesting
 {
+    
     public static class OptionExtensions
     {
-        public static void ShouldBeSome<T>(this Option<T> @this, Action<T> someValidation)
+        public static void ShouldBeSome<T>(this Option<T> @this,
+                                           Action<T> someValidation = null)
             => @this.Match(
-                Some: someValidation,
+                Some: someValidation ?? Common.Noop,
                 None: Common.ThrowIfNone);
 
         public static void ShouldBeNone<T>(this Option<T> @this)

--- a/LanguageExt.UnitTesting/TryAsyncExtensions.cs
+++ b/LanguageExt.UnitTesting/TryAsyncExtensions.cs
@@ -5,13 +5,16 @@ namespace LanguageExt.UnitTesting
 {
     public static class TryAsyncExtensions
     {
-        public static async Task ShouldBeSuccess<T>(this TryAsync<T> @this, Action<T> successValidation)
+        public static async Task ShouldBeSuccess<T>(this TryAsync<T> @this,
+                                                    Action<T> successValidation = null)
             => await @this.Match(
-                Succ: successValidation,
+                Succ: successValidation ?? Common.Noop,
                 Fail: _ => throw new Exception("Expected Success, got Fail instead.")
             );
 
-        public static async Task ShouldBeFail<T>(this TryAsync<T> @this, Action<Exception> failValidation)
-            => await @this.Match<T>(_ => throw new Exception("Expected Fail, got Success instead."), failValidation);
+        public static async Task ShouldBeFail<T>(this TryAsync<T> @this,
+                                                 Action<Exception> failValidation = null)
+            => await @this.Match<T>(Succ: _ => throw new Exception("Expected Fail, got Success instead."),
+                                    Fail: failValidation ?? Common.Noop);
     }
 }

--- a/LanguageExt.UnitTesting/TryAsyncExtensions.cs
+++ b/LanguageExt.UnitTesting/TryAsyncExtensions.cs
@@ -5,15 +5,13 @@ namespace LanguageExt.UnitTesting
 {
     public static class TryAsyncExtensions
     {
-        public static async Task ShouldBeSuccess<T>(this TryAsync<T> @this,
-                                                    Action<T> successValidation = null)
+        public static async Task ShouldBeSuccess<T>(this TryAsync<T> @this, Action<T> successValidation = null)
             => await @this.Match(
                 Succ: successValidation ?? Common.Noop,
                 Fail: _ => throw new Exception("Expected Success, got Fail instead.")
             );
 
-        public static async Task ShouldBeFail<T>(this TryAsync<T> @this,
-                                                 Action<Exception> failValidation = null)
+        public static async Task ShouldBeFail<T>(this TryAsync<T> @this, Action<Exception> failValidation = null)
             => await @this.Match<T>(Succ: _ => throw new Exception("Expected Fail, got Success instead."),
                                     Fail: failValidation ?? Common.Noop);
     }

--- a/LanguageExt.UnitTesting/TryExtensions.cs
+++ b/LanguageExt.UnitTesting/TryExtensions.cs
@@ -4,13 +4,10 @@ namespace LanguageExt.UnitTesting
 {
     public static class TryExtensions
     {
-        public static void ShouldBeSuccess<T>(this Try<T> @this,
-                                              Action<T> successValidation = null)
+        public static void ShouldBeSuccess<T>(this Try<T> @this, Action<T> successValidation = null)
             => @this.Match(successValidation ?? Common.Noop, Common.ThrowIfFail);
 
-        public static void ShouldBeFail<T>(this Try<T> @this,
-                                           Action<Exception> failValidation = null)
-            => @this.Match(Common.ThrowIfSuccess,
-                           failValidation ?? Common.Noop);
+        public static void ShouldBeFail<T>(this Try<T> @this, Action<Exception> failValidation = null)
+            => @this.Match(Common.ThrowIfSuccess, failValidation ?? Common.Noop);
     }
 }

--- a/LanguageExt.UnitTesting/TryExtensions.cs
+++ b/LanguageExt.UnitTesting/TryExtensions.cs
@@ -4,10 +4,13 @@ namespace LanguageExt.UnitTesting
 {
     public static class TryExtensions
     {
-        public static void ShouldBeSuccess<T>(this Try<T> @this, Action<T> successValidation)
-            => @this.Match(successValidation, Common.ThrowIfFail);
+        public static void ShouldBeSuccess<T>(this Try<T> @this,
+                                              Action<T> successValidation = null)
+            => @this.Match(successValidation ?? Common.Noop, Common.ThrowIfFail);
 
-        public static void ShouldBeFail<T>(this Try<T> @this, Action<Exception> failValidation)
-            => @this.Match(Common.ThrowIfSuccess, failValidation);
+        public static void ShouldBeFail<T>(this Try<T> @this,
+                                           Action<Exception> failValidation = null)
+            => @this.Match(Common.ThrowIfSuccess,
+                           failValidation ?? Common.Noop);
     }
 }

--- a/LanguageExt.UnitTesting/TryOptionAsyncExtensions.cs
+++ b/LanguageExt.UnitTesting/TryOptionAsyncExtensions.cs
@@ -5,8 +5,7 @@ namespace LanguageExt.UnitTesting
 {
     public static class TryOptionAsyncExtensions
     {
-        public static async Task ShouldBeSome<T>(this TryOptionAsync<T> @this,
-                                                 Action<T> someValidation = null)
+        public static async Task ShouldBeSome<T>(this TryOptionAsync<T> @this, Action<T> someValidation = null)
             => await @this.Match(
                 Some: someValidation ?? Common.Noop,
                 None: Common.ThrowIfNone,
@@ -20,15 +19,11 @@ namespace LanguageExt.UnitTesting
                 Fail: ex => throw ex
             );
 
-        public static async Task ShouldBeFail<T>(this TryOptionAsync<T> @this,
-                                                 Action<Exception> failValidation = null)
-        {
-            failValidation = failValidation ?? Common.Noop;
-            await @this.Match(
+        public static async Task ShouldBeFail<T>(this TryOptionAsync<T> @this, Action<Exception> failValidation = null)
+            => await @this.Match(
                 Some: Common.ThrowExpectedFailGotSome,
                 None: Common.ThrowExpectedFailGotNone,
-                Fail: ex => failValidation(ex)
-            );
-        }
-    }    
+                Fail: ex => (failValidation ?? Common.Noop)(ex)
+        );
+    }
 }

--- a/LanguageExt.UnitTesting/TryOptionAsyncExtensions.cs
+++ b/LanguageExt.UnitTesting/TryOptionAsyncExtensions.cs
@@ -5,9 +5,10 @@ namespace LanguageExt.UnitTesting
 {
     public static class TryOptionAsyncExtensions
     {
-        public static async Task ShouldBeSome<T>(this TryOptionAsync<T> @this, Action<T> someValidation)
+        public static async Task ShouldBeSome<T>(this TryOptionAsync<T> @this,
+                                                 Action<T> someValidation = null)
             => await @this.Match(
-                Some: someValidation,
+                Some: someValidation ?? Common.Noop,
                 None: Common.ThrowIfNone,
                 Fail: ex => throw ex
             );
@@ -18,12 +19,16 @@ namespace LanguageExt.UnitTesting
                 None: Common.SuccessfulNone,
                 Fail: ex => throw ex
             );
-        
-        public static async Task ShouldBeFail<T>(this TryOptionAsync<T> @this, Action<Exception> failValidation)
-            => await @this.Match(
+
+        public static async Task ShouldBeFail<T>(this TryOptionAsync<T> @this,
+                                                 Action<Exception> failValidation = null)
+        {
+            failValidation = failValidation ?? Common.Noop;
+            await @this.Match(
                 Some: Common.ThrowExpectedFailGotSome,
                 None: Common.ThrowExpectedFailGotNone,
                 Fail: ex => failValidation(ex)
             );
+        }
     }    
 }

--- a/LanguageExt.UnitTesting/TryOptionExtensions.cs
+++ b/LanguageExt.UnitTesting/TryOptionExtensions.cs
@@ -4,8 +4,7 @@ namespace LanguageExt.UnitTesting
 {
     public static class TryOptionExtensions
     {
-        public static void ShouldBeSome<T>(this TryOption<T> @this,
-                                           Action<T> someValidation = null)
+        public static void ShouldBeSome<T>(this TryOption<T> @this, Action<T> someValidation = null)
             => @this.Match(
                 Some: someValidation ?? Common.Noop,
                 None: Common.ThrowIfNone,
@@ -19,15 +18,11 @@ namespace LanguageExt.UnitTesting
                 Fail: ex => throw ex
             );
 
-        public static void ShouldBeFail<T>(this TryOption<T> @this,
-                                           Action<Exception> failValidation = null)
-        {
-            failValidation = failValidation ?? Common.Noop;
-            @this.Match(
+        public static void ShouldBeFail<T>(this TryOption<T> @this, Action<Exception> failValidation = null)
+            => @this.Match(
                 Some: Common.ThrowExpectedFailGotSome,
                 None: Common.ThrowExpectedFailGotNone,
-                Fail: ex => failValidation(ex)
-            );
-        }
+                Fail: ex => (failValidation ?? Common.Noop)(ex)
+        );
     }
 }

--- a/LanguageExt.UnitTesting/TryOptionExtensions.cs
+++ b/LanguageExt.UnitTesting/TryOptionExtensions.cs
@@ -4,9 +4,10 @@ namespace LanguageExt.UnitTesting
 {
     public static class TryOptionExtensions
     {
-        public static void ShouldBeSome<T>(this TryOption<T> @this, Action<T> someValidation)
+        public static void ShouldBeSome<T>(this TryOption<T> @this,
+                                           Action<T> someValidation = null)
             => @this.Match(
-                Some: someValidation,
+                Some: someValidation ?? Common.Noop,
                 None: Common.ThrowIfNone,
                 Fail: ex => throw ex
             );
@@ -18,11 +19,15 @@ namespace LanguageExt.UnitTesting
                 Fail: ex => throw ex
             );
 
-        public static void ShouldBeFail<T>(this TryOption<T> @this, Action<Exception> failValidation)
-            => @this.Match(
+        public static void ShouldBeFail<T>(this TryOption<T> @this,
+                                           Action<Exception> failValidation = null)
+        {
+            failValidation = failValidation ?? Common.Noop;
+            @this.Match(
                 Some: Common.ThrowExpectedFailGotSome,
                 None: Common.ThrowExpectedFailGotNone,
                 Fail: ex => failValidation(ex)
             );
+        }
     }
 }

--- a/LanguageExt.UnitTesting/ValidationExtentions.cs
+++ b/LanguageExt.UnitTesting/ValidationExtentions.cs
@@ -5,10 +5,14 @@ namespace LanguageExt.UnitTesting
 {
     public static class ValidationExtentions
     {
-        public static void ShouldBeSuccess<TFail, TSuccess>(this Validation<TFail, TSuccess> @this, Action<TSuccess> successValidation)
-            => @this.Match(successValidation, Common.ThrowIfFail);
+        public static void ShouldBeSuccess<TFail, TSuccess>(this Validation<TFail, TSuccess> @this,
+                                                            Action<TSuccess> successValidation = null)
+            => @this.Match(successValidation ?? Common.Noop,
+                           Common.ThrowIfFail);
 
-        public static void ShouldBeFail<TFail, TSuccess>(this Validation<TFail, TSuccess> @this, Action<IEnumerable<TFail>> failValidation)
-            => @this.Match(Common.ThrowIfSuccess, failValidation);
+        public static void ShouldBeFail<TFail, TSuccess>(this Validation<TFail, TSuccess> @this,
+                                                         Action<IEnumerable<TFail>> failValidation = null)
+            => @this.Match(Common.ThrowIfSuccess,
+                           failValidation ?? Common.Noop);
     }
 }

--- a/LanguageExt.UnitTesting/ValidationExtentions.cs
+++ b/LanguageExt.UnitTesting/ValidationExtentions.cs
@@ -7,12 +7,10 @@ namespace LanguageExt.UnitTesting
     {
         public static void ShouldBeSuccess<TFail, TSuccess>(this Validation<TFail, TSuccess> @this,
                                                             Action<TSuccess> successValidation = null)
-            => @this.Match(successValidation ?? Common.Noop,
-                           Common.ThrowIfFail);
+            => @this.Match(successValidation ?? Common.Noop, Common.ThrowIfFail);
 
         public static void ShouldBeFail<TFail, TSuccess>(this Validation<TFail, TSuccess> @this,
                                                          Action<IEnumerable<TFail>> failValidation = null)
-            => @this.Match(Common.ThrowIfSuccess,
-                           failValidation ?? Common.Noop);
+            => @this.Match(Common.ThrowIfSuccess, failValidation ?? Common.Noop);
     }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Option<int> subject = UnitUnderTest();
 // or the integer value wrapped by Some does not equal 5
 subject.ShouldBeSome(some => Assert.Equal(5, some));
 
+// the following line throws an exception if subject is Option<int>.None 
+subject.ShouldBeSome();
+
 // the following line throws an exception if subject is not Option<int>.None
 subject.ShouldBeNone();
 ```
@@ -26,6 +29,9 @@ OptionAsync<int> subject = UnitUnderTest();
 // the following line throws an exception if subject is OptionAsync<int>.None 
 // or the integer value wrapped by Some does not equal 5
 await subject.ShouldBeSome(some => Assert.Equal(5, some));
+
+// the following line throws an exception if subject is OptionAsync<int>.None 
+await subject.ShouldBeSome();
 
 // the following line throws an exception if subject is not OptionAsync<int>.None
 await subject.ShouldBeNone();
@@ -41,9 +47,15 @@ Validation<string, int> subject = UnitUnderTest();
 // or in case of successful validation the integer value does not equal 5
 subject.ShouldBeSuccess(success => Assert.Equal(5, success));
 
+// the following line throws an exception if subject represents failure
+subject.ShouldBeSuccess();
+
 // the following line throws an exception if subject does not represent failed validation
 // or in case of failed validation the failure value does not meet expectation
 subject.ShouldBeFail(errors => Assert("value is not valid", errors.First()));
+
+// the following line throws an exception if subject does not represent failed validation
+subject.ShouldBeFail();
 ```
 
 ## Either
@@ -56,9 +68,15 @@ Either<string, int> subject = UnitUnderTest();
 // or in case of right side of Either when the integer value does not equal 5
 subject.ShouldBeRight(right => Assert.Equal(5, right));
 
+// the following line throws an exception if subject represents left side of Either
+subject.ShouldBeRight();
+
 // the following line throws an exception if subject represents right side of Either
 // or in case of left side of Either when the string value does not equal "abcd"
 subject.ShouldBeLeft(left => Assert.Equal("abcd", left));
+
+// the following line throws an exception if subject represents right side of Either
+subject.ShouldBeLeft();
 ```
 
 
@@ -72,9 +90,15 @@ EitherAsync<string, int> subject = UnitUnderTest();
 // or in case of right side of Either when the integer value does not equal 5
 await subject.ShouldBeRight(right => Assert.Equal(5, right));
 
+// the following line throws an exception if subject represents left side of Either
+await subject.ShouldBeRight();
+
 // the following line throws an exception if subject represents right side of Either
 // or in case of left side of Either when the string value does not equal "abcd"
 await subject.ShouldBeLeft(left => Assert.Equal("abcd", left));
+
+// the following line throws an exception if subject represents right side of Either
+await subject.ShouldBeLeft();
 ```
 
 ## Try
@@ -87,9 +111,15 @@ Try<int> subject = UnitUnderTest();
 // or in case of successful try the integer value does not equal 5
 subject.ShouldBeSuccess(success => Assert.Equal(5, success));
 
+// the following line throws an exception if subject represents failure
+subject.ShouldBeSuccess();
+
 // the following line throws an exception if subject does not represent failure
 // or in case of failure the exception has wrong message
 subject.ShouldBeFail(ex => Assert.Equal("something went wrong", ex.Message));
+
+// the following line throws an exception if subject does not represent failure
+subject.ShouldBeFail();
 ```
 
 ## TryAsync
@@ -102,9 +132,15 @@ TryAsync<int> subject = UnitUnderTest();
 // or in case of successful try the integer value does not equal 5
 await subject.ShouldBeSuccess(success => Assert.Equal(5, success));
 
+// the following line throws an exception if subject represents failure
+await subject.ShouldBeSuccess();
+
 // the following line throws an exception if subject does not represent failure
 // or in case of failure the  exception has wrong message
 await subject.ShouldBeFail(ex => Assert.Equal("something went wrong", ex.Message));
+
+// the following line throws an exception if subject does not represent failure
+await subject.ShouldBeFail();
 ```
 
 ## TryOption
@@ -118,12 +154,18 @@ TryOption<int> subject = UnitUnderTest();
 // or the integer value wrapped by Some does not equal 5
 subject.ShouldBeSome(some => Assert.Equal(5, some));
 
+// the following line throws an exception if subject represents failure or Option<T>.None
+subject.ShouldBeSome(some => Assert.Equal(5, some));
+
 // the following line throws an exception if subject is not Option<int>.None
 subject.ShouldBeNone();
 
 // the following line throws an exception if subject does not represent failure
 // or in case of failure the exception has wrong message
 subject.ShouldBeFail(ex => Assert.Equal("something went wrong", ex.Message));
+
+// the following line throws an exception if subject does not represent failure
+subject.ShouldBeFail();
 ```
 
 ## TryOptionAsync
@@ -137,10 +179,16 @@ TryOptionAsync<int> subject = UnitUnderTest();
 // or the integer value wrapped by Some does not equal 5
 await subject.ShouldBeSome(some => Assert.Equal(5, some));
 
+// the following line throws an exception if subject represents failure or Option<T>.None
+await subject.ShouldBeSome();
+
 // the following line throws an exception if subject is not Option<int>.None
 await subject.ShouldBeNone();
 
 // the following line throws an exception if subject does not represent failure
 // or in case of failure the exception has wrong message
 await subject.ShouldBeFail(ex => Assert.Equal("something went wrong", ex.Message));
+
+// the following line throws an exception if subject does not represent failure
+await subject.ShouldBeFail();
 ```


### PR DESCRIPTION
Provides easier testing when the caller doesn't care what the value is, just it's presence.