### PR TITLE
Update to current LanguageExt-Version

### DIFF
--- a/LanguageExt.UnitTesting.Tests/LanguageExt.UnitTesting.Tests.csproj
+++ b/LanguageExt.UnitTesting.Tests/LanguageExt.UnitTesting.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.5.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/LanguageExt.UnitTesting/LanguageExt.UnitTesting.csproj
+++ b/LanguageExt.UnitTesting/LanguageExt.UnitTesting.csproj
@@ -18,13 +18,13 @@
     <PackageTags>LanguageExt</PackageTags>
     <PackageReleaseNotes>Adding non-validating extenstion method overloads (thanks @ovstetun for the contribution).</PackageReleaseNotes>
     <Copyright>Yuriy Lyeshchenko © 2018</Copyright>
-    <AssemblyVersion>3.1.14.0</AssemblyVersion>
-    <FileVersion>3.1.14.0</FileVersion>
-    <Version>3.1.14</Version>
+    <AssemblyVersion>3.3.5.0</AssemblyVersion>
+    <FileVersion>3.3.5.0</FileVersion>
+    <Version>3.3.5</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LanguageExt.Core" Version="3.1.14" />
+    <PackageReference Include="LanguageExt.Core" Version="3.3.5" />
   </ItemGroup>
 
 </Project>

--- a/LanguageExt.UnitTesting/ValidationExtentions.cs
+++ b/LanguageExt.UnitTesting/ValidationExtentions.cs
@@ -10,7 +10,7 @@ namespace LanguageExt.UnitTesting
             => @this.Match(successValidation ?? Common.Noop, Common.ThrowIfFail);
 
         public static void ShouldBeFail<TFail, TSuccess>(this Validation<TFail, TSuccess> @this,
-                                                         Action<IEnumerable<TFail>> failValidation = null)
+                                                         Action<Seq<TFail>> failValidation = null)
             => @this.Match(Common.ThrowIfSuccess, failValidation ?? Common.Noop);
     }
 }


### PR DESCRIPTION
LanguageExt.UnitTesting no longer works with LanguageExt 3.3. This pull request updates all references and changes the Validation-ShouldBeFail-Method to reflect the new signature (breaking change).